### PR TITLE
rsid tooltip display, export pdf

### DIFF
--- a/app/static/styles/visualise.css
+++ b/app/static/styles/visualise.css
@@ -49,3 +49,11 @@ input[data-id=color-picker]::-webkit-color-swatch {
     border: none;
     border-radius: 25%;
 }
+
+span.pdf-rsid {
+    display: none;
+}
+
+p:not(.hidden-colour) + span.pdf {
+    display: inline !important;
+}

--- a/app/templates/visualise.html
+++ b/app/templates/visualise.html
@@ -42,10 +42,10 @@
       <button type="button" class="rounded-0 sharp-color btn btn-light">px</button>
     </div>
     <button id="hide-individual-colour-btn" class="btn btn-light text-start" type="button">
-      <i class="fa-solid fa-eye-slash"></i> Show Matching Only
+      <i class="fa-solid fa-eye-slash"></i> Hide Individual RSIDs
     </button>
     <button id="hide-matching-colour-btn" class="btn btn-light text-start" type="button">
-      <i class="fa-solid fa-eye-slash"></i> Show Individual Only
+      <i class="fa-solid fa-eye-slash"></i> Hide Matching RSIDs
     </button>
   </div>
 </div>
@@ -53,22 +53,23 @@
 <div class="container-fluid" id="visualise-result-container">
   <div class="row mt-4 justify-content-around">
       {% for document in metadata_list %}
-        <div class="fluid-col-6 ps-1 pe-1">
-            <div class="card">
-                <div class="card-header">
-                    <h5>{{ document.file_name }}</h5>
-                    <small>Created on: {{ document.metadata.created.strftime('%Y-%m-%d %H:%M:%S') }}</small>
-                </div>
-                <div class="card-body" style="overflow-y: auto;" id="card-body-{{ loop.index }}">
-                    {% for paragraph in document.metadata.paragraphs %}
-                      <div class="my-2">
-                        {% for para in paragraph %}
-                          <p data-colour="{{ para.colour }}" data-rsid="{{ para.rsid }}" data-is-match="{{ 'true' if para.is_match else 'false' }}">{{ para.text }}</p>
-                        {% endfor %}
-                      </div>
-                    {% endfor %}
-                </div>
-            </div>
+        {% set position = 'left' if loop.index == 1 else 'right' %}
+        <div class="fluid-col-6 ps-1 pe-1" data-position="{{position}}">
+          <div class="card">
+              <div class="card-header">
+                  <h5>{{ document.file_name }}</h5>
+                  <small>Created on: {{ document.metadata.created.strftime('%Y-%m-%d %H:%M:%S') }}</small>
+              </div>
+              <div class="card-body" style="overflow-y: auto;" id="card-body-{{ loop.index }}">
+                  {% for paragraph in document.metadata.paragraphs %}
+                    <div class="my-2">
+                      {% for para in paragraph %}
+                        <p data-colour="{{ para.colour }}" data-rsid="{{ para.rsid }}" data-is-match="{{ 'true' if para.is_match else 'false' }}">{{ para.text }}</p>
+                      {% endfor %}
+                    </div>
+                  {% endfor %}
+              </div>
+          </div>
         </div>
       {% endfor %}
   </div>


### PR DESCRIPTION
- show rsid as tooltip on Page, trigger `click`, position based on the card position
- when selecting text such as select for copy, the tooltip should not show
- show rsid as text when export PDF, it should show based on the showing colour only
- when adjust font size, the rsid text should be adjusted too
- when switch doc, tooltip also need to update

# Related issue

- Resolve #68