### PR TITLE
Set fixed size for % match badge.

### DIFF
--- a/app/static/js/home.js
+++ b/app/static/js/home.js
@@ -364,7 +364,7 @@ function appendMatchResults(similarityResults) {
                     $('<i>', { class: 'fa-solid fa-hashtag me-1' }),
                     matchCount
                 ),
-                $('<span>', { class: `badge bg-primary me-2 ${badgeColour}` }).text(matchPercent === 0 ? '00.0%' : `${matchPercent.toFixed(1)}%`) // Match percentage
+                $('<span>', { class: `badge bg-primary me-2 ${badgeColour} fixed-width-badge` }).text(matchPercent === 0 ? '00.0%' : `${matchPercent.toFixed(1)}%`) // Match percentage
             );
             $row.append($fileInfo, $matchInfo);
             $mainContent.append($row);

--- a/app/static/styles/home.css
+++ b/app/static/styles/home.css
@@ -228,6 +228,11 @@
     gap: 10px; /* Ensures space between match count and percentage */
 }
 
+.fixed-width-badge {
+    width: 65px;
+    text-align:center;
+}
+
 /* Fixed width for match count to ensure alignment */
 .card-docx-container-list .match-count {
     min-width: 60px; /* Set a fixed width to ensure alignment */


### PR DESCRIPTION
Removed issue where badge size is different based on the %. At the moment have it center aligned.

New:
![Screen Shot 2024-10-02 at 12 18 40 pm](https://github.com/user-attachments/assets/f2ad9b0f-ecce-414e-b35d-cde2d79e3c76)


# Related issue

- Resolve #110