### PR TITLE
DockerHub Image

### DIFF
--- a/deployment/instance/containerOnBoot.service
+++ b/deployment/instance/containerOnBoot.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Start DocuMatcher container on boot/reload
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=simple
+User=ubuntu
+Restart=always
+ExecStart=/usr/bin/docker start DocuMatcher
+ExecStop=/usr/bin/docker stop DocuMatcher
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target

--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -9,6 +9,7 @@ events {
 http {
   include mime.types;
   default_type application/octet-stream;
+  client_max_body_size 0;
 
   log_format main '$remote_addr - $remote_user [$time_local] "$request" '
                   '$status $body_bytes_sent "$http_referer" '


### PR DESCRIPTION
# Brief
There were no changes to files required to create the DockerHub image and create a container service.

# Fixes
- NGINX file size limits on upload
- start container when lightsail instance boots